### PR TITLE
Derive Clone and Copy on SisoIirFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Chanelog
 
+## 0.2.2 - 2024-12-27
+
+### Changed
+
+* Derive Clone and Copy on `SisoIirFilter` to allow faster construction of batches of identical filters
+* Make `generated` module pub to provide access to min/max cutoff ratio bounds for generated filters
+
 ## 0.2.1 - 2024-12-26
 
 ### Changed
 
-* Lower align of SisoIirFilter struct and internal state arrays to 8
+* Lower align of `SisoIirFilter` struct and internal state arrays to 8
 
 ### Added
 
-* Add SisoIirFilter.initialize(u) to set the internal state vector to the steady-state values associated with a given measurement `u`
+* Add `SisoIirFilter.initialize(u)` to set the internal state vector to the steady-state values associated with a given measurement `u`
 
 ## 0.2.0 - 2024-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Derive Clone and Copy on `SisoIirFilter` to allow faster construction of batches of identical filters
 * Make `generated` module pub to provide access to min/max cutoff ratio bounds for generated filters
+* Loosen version requirement on num_traits dep
 
 ## 0.2.1 - 2024-12-26
 

--- a/flaw/Cargo.toml
+++ b/flaw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flaw"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-interpn = { version = "^0.4.2", default-features = false }
-num-traits = { version = "0.2.18", default-features = false, features = ["libm"] }
+interpn = { version = "^0.4.3", default-features = false }
+num-traits = { version = "^0.2.19", default-features = false, features = ["libm"] }
 
 [features]
 default = []

--- a/flaw/src/lib.rs
+++ b/flaw/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
-mod generated;
+pub mod generated;
 pub use generated::butter::butter1::butter1;
 pub use generated::butter::butter2::butter2;
 pub use generated::butter::butter3::butter3;
@@ -27,11 +27,13 @@ mod test {
 
 /// A simple array with large memory alignment because it will be accessed
 /// often in a loop
+#[derive(Clone, Copy)]
 #[repr(align(8))]
 struct AlignedArray<const N: usize>([f32; N]);
 
 /// Single-Input-Single-Output, Infinite Impulse Response filter,
 /// normalized to a sample time interval of 1.0
+#[derive(Clone, Copy)]
 #[repr(align(8))]
 pub struct SisoIirFilter<const ORDER: usize> {
     // Aligning the struct will usually keep these scalar fields aligned well enough


### PR DESCRIPTION
## 0.2.2 - 2024-12-27

### Changed

* Derive Clone and Copy on `SisoIirFilter` to allow faster construction of batches of identical filters
* Make `generated` module pub to provide access to min/max cutoff ratio bounds for generated filters
* Loosen version requirement on num_traits dep