### PR TITLE
Implement median filter & use ring buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# Chanelog
+# Changelog
+
+## 0.2.3 - 2025-01-01
+
+### Changed
+
+* Use ring buffer for IIR and median filter state storage
+* Lower align of SisoIirFilter struct, since the internal storage is already aligned
+
+### Added
+
+* Implement N-point median filter for odd N >= 3
 
 ## 0.2.2 - 2024-12-27
 

--- a/flaw/Cargo.toml
+++ b/flaw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flaw"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/flaw/README.md
+++ b/flaw/README.md
@@ -77,6 +77,12 @@ which are the result of a bilinear transform of the transfer function polynomial
 | Butter5| 10^-1.5 (~0.032)  | 0.4               |
 | Butter6| 10^-1.25 (~0.06)  | 0.4               |
 
+## Additional Filter Kinds
+
+| Filter | Notes |
+|--------|--------------------------------------------------------------------------------------------------------------|
+| Median | Available for odd numbers of taps. <br>Helpful for rejecting non-oscillatory noise, such as packet latency spikes.
+
 # License
 Licensed under either of
 

--- a/flaw/src/iir.rs
+++ b/flaw/src/iir.rs
@@ -1,0 +1,196 @@
+/// Infinite-impulse-response filtering on 32-bit floats
+
+// Required for float conversions from 64 to 32 bit and for f32::log10
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use super::{AlignedArray, Ring};
+
+/// Single-Input-Single-Output, Infinite Impulse Response filter,
+/// normalized to a sample time interval of 1.0
+#[derive(Clone, Copy)]
+pub struct SisoIirFilter<const ORDER: usize> {
+    // Aligning the struct will usually keep these scalar fields aligned well enough
+    /// Latest state estimate
+    y: f32,
+    /// State-space `D` scalar
+    d: f32,
+
+    /// Internal state buffer, state-space `X` vector
+    x: Ring<f32, ORDER>,
+    /// Nontrivial row of state-space `A` matrix in canonical form
+    a: AlignedArray<f32, ORDER>,
+    /// State-space `C` vector
+    c: AlignedArray<f32, ORDER>,
+}
+
+impl<const ORDER: usize> SisoIirFilter<ORDER> {
+    /// Evaluate the next estimated value based on the latest measurement
+    /// in 4N+1 floating-point ops for a filter of order N.
+    #[inline]
+    pub fn update(&mut self, u: f32) -> f32 {
+        // Both multiply-and-sum loops could be turned into chained mul-add,
+        // but microcontrollers mostly don't have
+        // mul-add instructions as of the year 2024, so using mul_add here
+        // would cause severe performance regression. Using chained mul-add
+        // on an unknown number of points also requires a recursion that
+        // may not be tail-call optimized because it contains a branch,
+        // resulting in further increased stack usage and reduced throughput.
+
+        // Split buffers into compatible slices
+        let x_parts = self.x.buf_parts(); // [first, second] both reversed
+        let n = x_parts.0.len(); // ring buffer split point w.r.t. contiguous vectors
+        let a_parts = self.a.0.split_at(n);
+        let c_parts = self.c.0.split_at(n);
+
+        // Y(k) = CX(k-1) + DU(k)
+        // 2N+1 float ops
+        // Sum starting with d*u because this term is the smallest,
+        // and `c` terms are ordered from smallest to largest.
+        // Summation from smallest to largest terms improves
+        // float roundoff error.
+        self.y = self.d * u;
+
+        self.y += c_parts
+            .0
+            .iter()
+            .zip(x_parts.0.iter().rev())
+            .map(|(cval, xval)| cval * xval)
+            .sum::<f32>();
+        self.y += c_parts
+            .1
+            .iter()
+            .zip(x_parts.1.iter().rev())
+            .map(|(cval, xval)| cval * xval)
+            .sum::<f32>();
+
+        // X(k) = AX(k-1) + BU(k)
+        // `B` in canonical form is like [1, 0, ...] and just selects the one nonzero value in `U`,
+        // which is the latest raw measurement.
+        // 2N float ops
+        //    Sum the first contiguous segment
+        let mut x0 = a_parts
+            .0
+            .iter()
+            .zip(x_parts.0.iter().rev())
+            .map(|(aval, xval)| aval * xval)
+            .sum::<f32>();
+        //    Sum the second contiguous segment
+        x0 += a_parts
+            .1
+            .iter()
+            .zip(x_parts.1.iter().rev())
+            .map(|(aval, xval)| aval * xval)
+            .sum::<f32>();
+        //    The one nontrivial element from BU(k)
+        //    This may not be small, so it is summed last to improve float roundoff
+        x0 += u;
+
+        // Update x0 and apply time delays
+        self.x.push(x0);
+
+        self.y
+    }
+
+    /// Populate a new filter with arbitrary state-space `A`, `C`, and `D`
+    /// in canonical form s.t. `A` values are the top row only
+    /// and `B` is assumed to be unity.
+    pub fn new(a: &[f32], c: &[f32], d: f32) -> Self {
+        let mut a_ = [0.0; ORDER];
+        a_.copy_from_slice(a);
+
+        let mut c_ = [0.0; ORDER];
+        c_.copy_from_slice(c);
+
+        Self {
+            y: 0.0,
+            x: Ring::new(0.0),
+            a: AlignedArray(a_),
+            c: AlignedArray(c_),
+            d,
+        }
+    }
+
+    /// Build a new low-pass with coefficients interpolated on baked tables.
+    /// After interpolation, the `C` vector is scaled by a (hopefully) small
+    /// amount to more closely produce unity steady-state gain.
+    pub fn new_interpolated(
+        cutoff_ratio: f64,
+        log10_cutoff_ratio_grid: &[f64],
+        avals: &[&[f64]],
+        cvals: &[&[f64]],
+        dvals: &[f64],
+    ) -> Result<Self, &'static str> {
+        let log10_cutoff_ratio = cutoff_ratio.log10();
+
+        // Check table bounds
+        let mut extrapolated = [false; 1];
+        interpn::multicubic::rectilinear::check_bounds(
+            &[log10_cutoff_ratio_grid],
+            &[&[log10_cutoff_ratio]],
+            1e-6,
+            &mut extrapolated,
+        )?;
+
+        if extrapolated[0] {
+            return Err("Selected cutoff ratio is outside the grid");
+        }
+
+        let mut a = [0.0; ORDER];
+        let mut c = [0.0; ORDER];
+
+        // Interpolate `A` values
+        for i in 0..ORDER {
+            a[i] = interpn::MulticubicRectilinear::<'_, _, 1>::new(
+                &[log10_cutoff_ratio_grid],
+                avals[i],
+                true,
+            )?
+            .interp_one(&[log10_cutoff_ratio])? as f32;
+        }
+
+        // Interpolate `C` values
+        for i in 0..ORDER {
+            c[i] = interpn::MulticubicRectilinear::<'_, _, 1>::new(
+                &[log10_cutoff_ratio_grid],
+                cvals[i],
+                true,
+            )?
+            .interp_one(&[log10_cutoff_ratio])? as f32;
+        }
+
+        // Interpolate `D` value
+        let d = interpn::MulticubicRectilinear::<'_, _, 1>::new(
+            &[log10_cutoff_ratio_grid],
+            dvals,
+            true,
+        )?
+        .interp_one(&[log10_cutoff_ratio])? as f32;
+
+        // Scale `C` to enforce unity gain at zero frequency, that is,
+        // that the step response should converge exactly.
+        //
+        // First, find scalar `xs` for every entry in filter state vector `x`
+        // such that x(k) == x(k-1).
+        let asum = a.iter().sum::<f32>() as f64;
+        let xs = 1.0 / (1.0 - asum);
+        // Then, find what the sum of `C` _should_ be to produce unity gain,
+        // and use that value to calculate a scale factor for the existing `C`.
+        let csum_desired = (1.0 - d as f64) / xs;
+        let csum = c.iter().sum::<f32>() as f64;
+        let scale_factor = (csum_desired / csum) as f32;
+        // Finally, scale `C` to, as closely as possible, produce unity gain.
+        c.iter_mut().for_each(|v| *v *= scale_factor);
+
+        Ok(Self::new(&a, &c, d))
+    }
+
+    /// Initialize filter internal state to the steady value
+    /// achieved for input `u`. For filters with unity steady-state gain,
+    /// this will also produce an output reading of `u`.
+    pub fn initialize(&mut self, u: f32) {
+        let asum: f32 = self.a.0.iter().sum();
+        let xs = u / (1.0 - asum); // Scalar constant value for `X` entries
+        self.x = Ring::new(xs);
+    }
+}

--- a/flaw/src/lib.rs
+++ b/flaw/src/lib.rs
@@ -1,5 +1,11 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+mod iir;
+mod median;
+
+pub use iir::SisoIirFilter;
+pub use median::MedianFilter;
+
 pub mod generated;
 pub use generated::butter::butter1::butter1;
 pub use generated::butter::butter2::butter2;
@@ -8,9 +14,54 @@ pub use generated::butter::butter4::butter4;
 pub use generated::butter::butter5::butter5;
 pub use generated::butter::butter6::butter6;
 
-// Required for float conversions from 64 to 32 bit and for f32::log10
-#[cfg(not(feature = "std"))]
-use num_traits::Float;
+/// A simple array with large memory alignment because it will be accessed
+/// often in a loop
+#[derive(Clone, Copy)]
+#[repr(align(8))]
+struct AlignedArray<T, const N: usize>([T; N]);
+
+/// Ring buffer
+#[derive(Clone, Copy)]
+struct Ring<T: Copy, const N: usize> {
+    buf: AlignedArray<T, N>,
+    next: usize,
+}
+
+impl<T: Copy, const N: usize> Ring<T, N> {
+
+    /// Initialize with buffer populated with constant value
+    fn new(value: T) -> Self {
+        Self {
+            buf: AlignedArray([value; N]),
+            next: 0
+        }
+    }
+
+    /// Replace the oldest value in the buffer with a new value
+    fn push(&mut self, value: T) {
+        self.buf.0[self.next] = value;
+        self.next += 1;
+        if self.next == N {
+            self.next = 0;
+        }
+    }
+
+    /// The whole internal buffer, with no indication of the current index
+    fn buf(&self) -> &[T; N] {
+        &self.buf.0
+    }
+
+    /// Contiguous parts of the buffer split across the next insertion point
+    /// s.t. the first slice includes values from index 0 to the most recently
+    /// inserted value.
+    /// 
+    /// To iterate over the items in order of insertion from most recent to oldest,
+    /// loop over the first slice, then the second, both in reverse.
+    fn buf_parts(&self) -> (&[T], &[T]) {
+        self.buf.0.split_at(self.next)
+    }
+}
+
 
 /// `std` is required for tests, but is not a default feature.
 /// To allow the library to compile with default features,
@@ -25,178 +76,6 @@ mod test {
     }
 }
 
-/// A simple array with large memory alignment because it will be accessed
-/// often in a loop
-#[derive(Clone, Copy)]
-#[repr(align(8))]
-struct AlignedArray<const N: usize>([f32; N]);
-
-/// Single-Input-Single-Output, Infinite Impulse Response filter,
-/// normalized to a sample time interval of 1.0
-#[derive(Clone, Copy)]
-#[repr(align(8))]
-pub struct SisoIirFilter<const ORDER: usize> {
-    // Aligning the struct will usually keep these scalar fields aligned well enough
-    /// Latest state estimate
-    y: f32,
-    /// State-space `D` scalar
-    d: f32,
-
-    /// Internal state buffer, state-space `X` vector
-    x: AlignedArray<ORDER>,
-    /// Nontrivial row of state-space `A` matrix in canonical form
-    a: AlignedArray<ORDER>,
-    /// State-space `C` vector
-    c: AlignedArray<ORDER>,
-}
-
-impl<const ORDER: usize> SisoIirFilter<ORDER> {
-    /// Evaluate the next estimated value based on the latest measurement
-    /// in 4N+1 floating-point ops for a filter of order N.
-    #[inline]
-    pub fn update(&mut self, u: f32) -> f32 {
-        // Both multiply-and-sum loops could be turned into chained mul-add,
-        // but microcontrollers mostly don't have
-        // mul-add instructions as of the year 2024, so using mul_add here
-        // would cause severe performance regression. Using chained mul-add
-        // on an unknown number of points also requires a recursion that
-        // may not be tail-call optimized because it contains a branch,
-        // resulting in further increased stack usage and reduced throughput.
-
-        // Y(k) = CX(k-1) + DU(k)
-        // 2N+1 float ops
-        // Sum starting with d*u because this term is the smallest,
-        // and `c` terms are ordered from smallest to largest.
-        // Summation from smallest to largest terms improves
-        // float roundoff error.
-        self.y = self
-            .c
-            .0
-            .iter()
-            .zip(self.x.0.iter())
-            .fold(self.d * u, |acc, (cval, xval)| acc + cval * xval);
-
-        // X(k) = AX(k-1) + BU(k)
-        // `B` in canonical form is like [1, 0, ...] and just selects the one nonzero value in `U`,
-        // which is the latest raw measurement.
-        // 2N float ops
-        let x0 = self
-            .a
-            .0
-            .iter()
-            .rev()
-            .zip(self.x.0.iter().rev())
-            .map(|(aval, xval)| aval * xval)
-            .sum::<f32>()
-            + u; // The one nontrivial element from BU(k)
-        (0..ORDER - 1).for_each(|i| self.x.0[ORDER - 1 - i] = self.x.0[ORDER - 2 - i]); // Time delays
-        self.x.0[0] = x0;
-
-        self.y
-    }
-
-    /// Populate a new filter with arbitrary state-space `A`, `C`, and `D`
-    /// in canonical form s.t. `A` values are the top row only
-    /// and `B` is assumed to be unity.
-    pub fn new(a: &[f32], c: &[f32], d: f32) -> Self {
-        let mut a_ = [0.0; ORDER];
-        a_.copy_from_slice(a);
-
-        let mut c_ = [0.0; ORDER];
-        c_.copy_from_slice(c);
-
-        Self {
-            y: 0.0,
-            x: AlignedArray([0.0; ORDER]),
-            a: AlignedArray(a_),
-            c: AlignedArray(c_),
-            d,
-        }
-    }
-
-    /// Build a new low-pass with coefficients interpolated on baked tables.
-    /// After interpolation, the `C` vector is scaled by a (hopefully) small
-    /// amount to more closely produce unity steady-state gain.
-    pub fn new_interpolated(
-        cutoff_ratio: f64,
-        log10_cutoff_ratio_grid: &[f64],
-        avals: &[&[f64]],
-        cvals: &[&[f64]],
-        dvals: &[f64],
-    ) -> Result<Self, &'static str> {
-        let log10_cutoff_ratio = cutoff_ratio.log10();
-
-        // Check table bounds
-        let mut extrapolated = [false; 1];
-        interpn::multicubic::rectilinear::check_bounds(
-            &[log10_cutoff_ratio_grid],
-            &[&[log10_cutoff_ratio]],
-            1e-6,
-            &mut extrapolated,
-        )?;
-
-        if extrapolated[0] {
-            return Err("Selected cutoff ratio is outside the grid");
-        }
-
-        let mut a = [0.0; ORDER];
-        let mut c = [0.0; ORDER];
-
-        // Interpolate `A` values
-        for i in 0..ORDER {
-            a[i] = interpn::MulticubicRectilinear::<'_, _, 1>::new(
-                &[log10_cutoff_ratio_grid],
-                avals[i],
-                true,
-            )?
-            .interp_one(&[log10_cutoff_ratio])? as f32;
-        }
-
-        // Interpolate `C` values
-        for i in 0..ORDER {
-            c[i] = interpn::MulticubicRectilinear::<'_, _, 1>::new(
-                &[log10_cutoff_ratio_grid],
-                cvals[i],
-                true,
-            )?
-            .interp_one(&[log10_cutoff_ratio])? as f32;
-        }
-
-        // Interpolate `D` value
-        let d = interpn::MulticubicRectilinear::<'_, _, 1>::new(
-            &[log10_cutoff_ratio_grid],
-            dvals,
-            true,
-        )?
-        .interp_one(&[log10_cutoff_ratio])? as f32;
-
-        // Scale `C` to enforce unity gain at zero frequency, that is,
-        // that the step response should converge exactly.
-        //
-        // First, find scalar `xs` for every entry in filter state vector `x`
-        // such that x(k) == x(k-1).
-        let asum = a.iter().sum::<f32>() as f64;
-        let xs = 1.0 / (1.0 - asum);
-        // Then, find what the sum of `C` _should_ be to produce unity gain,
-        // and use that value to calculate a scale factor for the existing `C`.
-        let csum_desired = (1.0 - d as f64) / xs;
-        let csum = c.iter().sum::<f32>() as f64;
-        let scale_factor = (csum_desired / csum) as f32;
-        // Finally, scale `C` to, as closely as possible, produce unity gain.
-        c.iter_mut().for_each(|v| *v *= scale_factor);
-
-        Ok(Self::new(&a, &c, d))
-    }
-
-    /// Initialize filter internal state to the steady value
-    /// achieved for input `u`. For filters with unity steady-state gain,
-    /// this will also produce an output reading of `u`.
-    pub fn initialize(&mut self, u: f32) {
-        let asum: f32 = self.a.0.iter().sum();
-        let xs = u / (1.0 - asum); // Scalar constant value for `X` entries
-        self.x.0.iter_mut().for_each(|x| *x = xs);
-    }
-}
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/flaw/src/lib.rs
+++ b/flaw/src/lib.rs
@@ -28,12 +28,11 @@ struct Ring<T: Copy, const N: usize> {
 }
 
 impl<T: Copy, const N: usize> Ring<T, N> {
-
     /// Initialize with buffer populated with constant value
     fn new(value: T) -> Self {
         Self {
             buf: AlignedArray([value; N]),
-            next: 0
+            next: 0,
         }
     }
 
@@ -54,14 +53,13 @@ impl<T: Copy, const N: usize> Ring<T, N> {
     /// Contiguous parts of the buffer split across the next insertion point
     /// s.t. the first slice includes values from index 0 to the most recently
     /// inserted value.
-    /// 
+    ///
     /// To iterate over the items in order of insertion from most recent to oldest,
     /// loop over the first slice, then the second, both in reverse.
     fn buf_parts(&self) -> (&[T], &[T]) {
         self.buf.0.split_at(self.next)
     }
 }
-
 
 /// `std` is required for tests, but is not a default feature.
 /// To allow the library to compile with default features,
@@ -75,7 +73,6 @@ mod test {
         panic!("`std` feature is required for tests")
     }
 }
-
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/flaw/src/median.rs
+++ b/flaw/src/median.rs
@@ -1,0 +1,102 @@
+//! Median filter on arbitrary partially-ordered type.
+
+use super::Ring;
+
+/// In-place insertion sort method.
+///
+/// Yoinked without modification from the `sorts` crate
+/// in order to use in a no-std environment which is not
+/// supported by the original.
+fn insertion_sort<T: PartialOrd>(s: &mut [T]) {
+    for i in 1..s.len() {
+        let mut j = i;
+        while j > 0 && s[j - 1] > s[j] {
+            s.swap(j - 1, j);
+            j -= 1;
+        }
+    }
+}
+
+/// Simple median filter on arbitrary ordered type.
+/// Requires an odd number of points to make the median unique.
+///
+/// Due to the fact that rust's slice::sort method is part of `alloc`,
+/// this uses an insertion sort method instead. Because of this, it is
+/// not recommended for large `N`, but is likely faster than other sort methods
+/// when used for appropriately small `N`.
+///
+/// Note that while this method only requires `PartialOrd`, which allows it
+/// to be used with float values, care must be taken not to poison the buffer
+/// with NaN values, which will cause the identification of the median to fail
+/// silently. Because the .is_finite() method is only available for floats,
+/// and not for other numeric types, guards against this failure must be
+/// implemented on the inputs given to this filter, and can't be implemented
+/// inside the filter update.
+pub struct MedianFilter<T: PartialOrd + Copy, const N: usize> {
+    vals: Ring<T, N>,
+    buf: [T; N],
+    imid: usize,
+}
+
+impl<T: PartialOrd + Copy, const N: usize> MedianFilter<T, N> {
+    /// Initialize with the buffer fully populated with the supplied value `v`
+    pub fn new(v: T) -> Self {
+        const {
+            assert!(N >= 3);
+            assert!(N % 2 == 1);
+        }
+
+        let imid = N / 2; // Index of middle of buffer
+
+        Self {
+            vals: Ring::new(v),
+            buf: [v; N],
+            imid,
+        }
+    }
+
+    /// Push a new value and return the new median
+    pub fn update(&mut self, v: T) -> T {
+        // Roll input buffer
+        self.vals.push(v);
+
+        // Copy, sort, and take the middle element
+        // As long as N is small, this will be fast
+        self.buf.copy_from_slice(self.vals.buf());
+        insertion_sort(&mut self.buf);
+        let median = self.buf[self.imid];
+
+        median
+    }
+}
+
+
+#[cfg(feature = "std")]
+#[cfg(test)]
+mod test {
+    /// Test initialization to a given input value
+    #[test]
+    fn test_median() {
+        use super::MedianFilter;
+
+        let inp = [2_u32, 5, 6, 7, 8, 4, 9, 0, 1, 3];
+
+        // 3-point
+        let expected = [0,2,5,6,7,7,8,4,1,1];
+        let mut f = MedianFilter::<u32, 3>::new(0);
+        for i in 0..inp.len() {
+            let v = f.update(inp[i]);
+            let e = expected[i];
+            assert!(v == e, "{i}: {v} != {e}");
+        }
+
+        // 5-point
+        let expected = [0, 0, 2, 5, 6, 6, 7, 7, 4, 3];
+        let mut f = MedianFilter::<u32, 5>::new(0);
+        for i in 0..inp.len() {
+            let v = f.update(inp[i]);
+            let e = expected[i];
+            assert!(v == e, "{i}: {v} != {e}");
+        }
+    }
+}

--- a/flaw/src/median.rs
+++ b/flaw/src/median.rs
@@ -70,7 +70,6 @@ impl<T: PartialOrd + Copy, const N: usize> MedianFilter<T, N> {
     }
 }
 
-
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod test {
@@ -82,7 +81,7 @@ mod test {
         let inp = [2_u32, 5, 6, 7, 8, 4, 9, 0, 1, 3];
 
         // 3-point
-        let expected = [0,2,5,6,7,7,8,4,1,1];
+        let expected = [0, 2, 5, 6, 7, 7, 8, 4, 1, 1];
         let mut f = MedianFilter::<u32, 3>::new(0);
         for i in 0..inp.len() {
             let v = f.update(inp[i]);


### PR DESCRIPTION
## 0.2.3 - 2025-01-01

### Changed

* Use ring buffer for IIR and median filter state storage
* Lower align of SisoIirFilter struct, since the internal storage is already aligned

### Added

* Implement N-point median filter for odd N >= 3