### PR TITLE
Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 - 2025-08-31
 
 Various performance-related improvements.
+~20% improvement in speed based on testing on an STM32H7 microcontroller.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Various performance-related improvements.
 * Add `u` value as initial for A*x dot product
     * (Potentially substantially) Improves float error for small values of latest measurement
       `u` at the expense of slightly worse float error for large `u`
-* Update flop counter per eval to 4N-1
+* Update flop per eval count to 4N-1
+* Update rust edition to 2024
 
 ## 0.2.5 - 2025-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.0 - 2025-08-31
+
+Various performance-related improvements.
+
+### Changed
+
+* !Store filter coeffs and taps in opposite order (most-recent-last) to improve vectorization
+* !Const-unroll compute intensive loops
+    * !Limit size of FIR filters to <128 taps
+    * !Limit order of polynomial fractional delay filters to <=10
+* Add `u` value as initial for A*x dot product
+    * (Potentially substantially) Improves float error for small values of latest measurement
+      `u` at the expense of slightly worse float error for large `u`
+* Update flop counter per eval to 4N-1
+
 ## 0.2.5 - 2025-05-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # flaw
-Control-law-inspired embedded signal filtering, no-std and no-alloc compatible.
+Embedded signal filtering, no-std and no-alloc compatible.
 
 This library provides a simple method for initializing and updating single-input,
 single-output infinite-impulse-response filters using 32-bit floats, as well as
@@ -9,8 +9,8 @@ tabulated filter coefficients for some common filters. Filters evaluate in
 The name `flaw` is short for filter-law, but also refers to the fact that
 digital IIR filtering with small floating-point types is an inherently flawed
 approach, in that higher-order and lower-cutoff filters produce very small
-coefficients that result in floating-point roundoff error. This library makes
-an attempt to mitigate this problem by providing filter coefficients for a tested
+coefficients that result in floating-point roundoff error. This library mitigates
+that problem by providing filter coefficients for a tested
 domain of validity. The result is a limited, but useful, range of operation
 where these filters can achieve both accuracy and performance as well
 as be formulated and initialized in an embedded environment.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Embedded signal filtering, no-std and no-alloc compatible.
 This library provides a simple method for initializing and updating single-input,
 single-output infinite-impulse-response filters using 32-bit floats, as well as
 tabulated filter coefficients for some common filters. Filters evaluate in
-4N+1 floating-point operations for a filter of order N.
+4N-1 floating-point operations for a filter of order N.
 
 The name `flaw` is short for filter-law, but also refers to the fact that
 digital IIR filtering with small floating-point types is an inherently flawed

--- a/flaw/Cargo.toml
+++ b/flaw/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flaw"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -12,6 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crunchy = "0.2.4"
 interpn = { version = "^0.4.5", default-features = false }
 num-traits = { version = "^0.2.19", default-features = false, features = ["libm"] }
 

--- a/flaw/Cargo.toml
+++ b/flaw/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "flaw"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 authors = ["James Logan <jlogan03@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jlogan03/flaw/"
 homepage = "https://github.com/jlogan03/flaw/flaw"
-description = "Control-law-inspired embedded signal filtering, no-std and no-alloc compatible."
+description = "Embedded signal filtering, no-std and no-alloc compatible."
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/flaw/README.md
+++ b/flaw/README.md
@@ -1,5 +1,5 @@
 # flaw
-Control-law-inspired embedded signal filtering, no-std and no-alloc compatible.
+Embedded signal filtering, no-std and no-alloc compatible.
 
 This library provides a simple method for initializing and updating single-input,
 single-output infinite-impulse-response filters using 32-bit floats, as well as
@@ -9,8 +9,8 @@ tabulated filter coefficients for some common filters. Filters evaluate in
 The name `flaw` is short for filter-law, but also refers to the fact that
 digital IIR filtering with small floating-point types is an inherently flawed
 approach, in that higher-order and lower-cutoff filters produce very small
-coefficients that result in floating-point roundoff error. This library makes
-an attempt to mitigate this problem by providing filter coefficients for a tested
+coefficients that result in floating-point roundoff error. This library mitigates
+that problem by providing filter coefficients for a tested
 domain of validity. The result is a limited, but useful, range of operation
 where these filters can achieve both accuracy and performance as well
 as be formulated and initialized in an embedded environment.

--- a/flaw/README.md
+++ b/flaw/README.md
@@ -4,7 +4,7 @@ Embedded signal filtering, no-std and no-alloc compatible.
 This library provides a simple method for initializing and updating single-input,
 single-output infinite-impulse-response filters using 32-bit floats, as well as
 tabulated filter coefficients for some common filters. Filters evaluate in
-4N+1 floating-point operations for a filter of order N.
+4N-1 floating-point operations for a filter of order N.
 
 The name `flaw` is short for filter-law, but also refers to the fact that
 digital IIR filtering with small floating-point types is an inherently flawed

--- a/flaw/src/fir.rs
+++ b/flaw/src/fir.rs
@@ -10,7 +10,7 @@ pub struct SisoFirFilter<const ORDER: usize, T: Num + Copy> {
     y: T,
     /// Internal sample buffer
     x: Ring<T, ORDER>,
-    /// Filter taps ordered from most-recent sample to least-recent sample
+    /// Filter taps ordered most-recent-last
     taps: AlignedArray<T, ORDER>,
 }
 
@@ -26,7 +26,7 @@ impl<const ORDER: usize, T: Num + Copy> SisoFirFilter<ORDER, T> {
     }
 
     /// Populate a new filter with arbitrary taps.
-    /// Filter taps ordered from most-recent sample to least-recent sample.
+    /// Filter taps are ordered most-recent-last.
     pub fn new(taps: &[T]) -> Self {
         let mut taps_ = [T::zero(); ORDER];
         taps_.copy_from_slice(taps);


### PR DESCRIPTION
## 0.3.0 - 2025-08-31

Various performance-related improvements.
~20% improvement in speed based on testing on an STM32H7 microcontroller.

### Changed

* !Store filter coeffs and taps in opposite order (most-recent-last) to improve vectorization
* !Const-unroll compute intensive loops
    * !Limit size of FIR filters to <128 taps
    * !Limit order of polynomial fractional delay filters to <=10
* Add `u` value as initial for A*x dot product
    * (Potentially substantially) Improves float error for small values of latest measurement
      `u` at the expense of slightly worse float error for large `u`
* Update flop per eval count to 4N-1
* Update rust edition to 2024